### PR TITLE
Rewrite some part of the API

### DIFF
--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/comments/vertical/pager/PageViewModel.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/comments/vertical/pager/PageViewModel.kt
@@ -27,7 +27,7 @@ class PageViewModel(private val booru: Boor) : ViewModel() {
 
     private fun loadDataForObserver(page: Int) {
         GlobalScope.launch {
-            val value = booru.getListOfLastCommentedPosts(page, booru.client)
+            val value = booru.getListOfLastCommentedPosts(page)
             runOnUi { liveData.value = value }
         }
     }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/comments/vertical/pager/PageViewModel.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/comments/vertical/pager/PageViewModel.kt
@@ -1,22 +1,19 @@
 package com.makentoshe.booruchan.booru.content.comments.vertical.pager
 
 import android.arch.lifecycle.*
-import android.arch.lifecycle.Observer
 import com.makentoshe.booruchan.booru.content.model.Downloader
 import com.makentoshe.booruchan.booru.content.model.PreviewLoader
 import com.makentoshe.booruchan.common.api.Boor
-import com.makentoshe.booruchan.common.api.HttpClient
 import com.makentoshe.booruchan.common.api.entity.Comment
 import com.makentoshe.booruchan.common.api.entity.Post
 import com.makentoshe.booruchan.common.runOnUi
 import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.launch
 
-class PageViewModel(private val booru: Boor,
-                    private val client: HttpClient) : ViewModel() {
+class PageViewModel(private val booru: Boor) : ViewModel() {
 
     private val liveData = MutableLiveData<List<Pair<Post, List<Comment>>>>()
-    @JvmField val previewLoader = PreviewLoader(Downloader(client))
+    @JvmField val previewLoader = PreviewLoader(Downloader(booru.client))
 
     fun getCommentedPosts(page: Int, lifecycleOwner: LifecycleOwner,
                           observer: (List<Pair<Post, List<Comment>>>?) -> (Unit)) {
@@ -30,7 +27,7 @@ class PageViewModel(private val booru: Boor,
 
     private fun loadDataForObserver(page: Int) {
         GlobalScope.launch {
-            val value = booru.getListOfLastCommentedPosts(page, client)
+            val value = booru.getListOfLastCommentedPosts(page, booru.client)
             runOnUi { liveData.value = value }
         }
     }
@@ -39,7 +36,7 @@ class PageViewModel(private val booru: Boor,
 
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass == PageViewModel::class.java) {
-                return PageViewModel(booru, HttpClient()) as T
+                return PageViewModel(booru) as T
             }
             return super.create(modelClass)
         }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/model/AutocompleteAdapter.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/model/AutocompleteAdapter.kt
@@ -21,8 +21,7 @@ class AutocompleteAdapter(private val context: Context, private val boor: Boor) 
             override fun performFiltering(constraint: CharSequence?): FilterResults = runBlocking {
                 val results = FilterResults()
                 if (constraint != null) {
-                    val tips = boor.getAutocompleteSearchVariations(
-                            HttpClient(), split(constraint.toString()))
+                    val tips = boor.getAutocompleteSearchVariations(split(constraint.toString()))
                     results.values = tips
                     results.count = tips.size
                 }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/model/AutocompleteAdapter.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/model/AutocompleteAdapter.kt
@@ -9,7 +9,6 @@ import android.widget.Filter
 import android.widget.Filterable
 import android.widget.TextView
 import com.makentoshe.booruchan.common.api.Boor
-import com.makentoshe.booruchan.common.api.HttpClient
 import kotlinx.coroutines.experimental.runBlocking
 
 class AutocompleteAdapter(private val context: Context, private val boor: Boor) : BaseAdapter(), Filterable {

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/model/Downloader.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/model/Downloader.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.experimental.launch
 import java.io.InputStream
 import java.lang.Exception
 
-class Downloader(val client: HttpClient) {
+class Downloader(private val client: HttpClient) {
 
     fun download(url: String, action: (InputStream?) -> (Unit)): Job {
         return GlobalScope.launch { action(client.get(url).stream()) }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/posts/infinity/ordered/PostsViewModel.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/posts/infinity/ordered/PostsViewModel.kt
@@ -3,22 +3,18 @@ package com.makentoshe.booruchan.booru.content.posts.infinity.ordered
 import android.arch.lifecycle.ViewModelProvider
 import android.support.v4.app.FragmentActivity
 import android.support.v7.widget.RecyclerView
-import com.makentoshe.booruchan.booru.content.posts.infinity.ordered.model.AdapterDataLoaderBuilder
-import com.makentoshe.booruchan.booru.content.model.Downloader
 import com.makentoshe.booruchan.booru.content.posts.BooruPostNavigator
 import com.makentoshe.booruchan.booru.content.posts.ViewModel
+import com.makentoshe.booruchan.booru.content.posts.infinity.ordered.model.AdapterDataLoaderBuilder
 import com.makentoshe.booruchan.booru.content.posts.infinity.ordered.model.RecycleViewAdapter
 import com.makentoshe.booruchan.common.api.Boor
-import com.makentoshe.booruchan.common.api.HttpClient
 import com.makentoshe.booruchan.common.settings.application.AppSettings
 
 class PostsViewModel(@JvmField val booru: Boor,
-                     @JvmField val appSettings: AppSettings,
-                     client: HttpClient) : ViewModel() {
+                     @JvmField val appSettings: AppSettings) : ViewModel() {
 
     private lateinit var currentGalleryAdapter: RecycleViewAdapter
-    private val downloader = Downloader(client)
-    private val adapterLoaderBuilder = AdapterDataLoaderBuilder(downloader, booru)
+    private val adapterLoaderBuilder = AdapterDataLoaderBuilder(booru)
     private var searchTerm = ""
     private val navigator = BooruPostNavigator()
 
@@ -54,7 +50,7 @@ class PostsViewModel(@JvmField val booru: Boor,
     class Factory(private val booru: Boor, private val appSettings: AppSettings) : ViewModelProvider.NewInstanceFactory() {
         override fun <T : android.arch.lifecycle.ViewModel?> create(modelClass: Class<T>): T {
             if (modelClass == PostsViewModel::class.java) {
-                return PostsViewModel(booru, appSettings, HttpClient()) as T
+                return PostsViewModel(booru, appSettings) as T
             }
             return super.create(modelClass)
         }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/posts/infinity/ordered/model/AdapterDataLoader.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/posts/infinity/ordered/model/AdapterDataLoader.kt
@@ -11,8 +11,7 @@ import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.delay
 import kotlinx.coroutines.experimental.launch
 
-class AdapterDataLoader(val searchTerm: String = "",
-                        private val downloader: Downloader,
+class AdapterDataLoader(val searchTerm: String = "", downloader: Downloader,
                         private val booru: Boor) : PreviewLoader(downloader) {
 
     private val postDataLoadScheduler = JobScheduler(10)
@@ -22,7 +21,7 @@ class AdapterDataLoader(val searchTerm: String = "",
             var errWasNotShown = true
             do {
                 try {
-                    action(booru.getPostsByTags(3, searchTerm, position, downloader.client))
+                    action(booru.getPostsByTags(3, searchTerm, position))
                     break
                 } catch (e: Exception) {
                     if (errWasNotShown) {
@@ -39,7 +38,7 @@ class AdapterDataLoader(val searchTerm: String = "",
     fun getPostsData2(position: Int, action: (Posts<out Post>) -> Unit) {
         val job = GlobalScope.launch(Dispatchers.Default) {
             delay(100)
-            action(booru.getPostsByTags(3, searchTerm, position, downloader.client))
+            action(booru.getPostsByTags(3, searchTerm, position))
         }
         postDataLoadScheduler.addJob(job)
     }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/posts/infinity/ordered/model/AdapterDataLoaderBuilder.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/posts/infinity/ordered/model/AdapterDataLoaderBuilder.kt
@@ -3,7 +3,7 @@ package com.makentoshe.booruchan.booru.content.posts.infinity.ordered.model
 import com.makentoshe.booruchan.booru.content.model.Downloader
 import com.makentoshe.booruchan.common.api.Boor
 
-class AdapterDataLoaderBuilder(private val downloader: Downloader, private val booru: Boor) {
+class AdapterDataLoaderBuilder(private val booru: Boor, private val downloader: Downloader = Downloader(booru.client)) {
 
     fun build(searchTerm: String): AdapterDataLoader {
         return AdapterDataLoader(searchTerm, downloader, booru)

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/settings/SettingsContentViewModel.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/settings/SettingsContentViewModel.kt
@@ -3,16 +3,15 @@ package com.makentoshe.booruchan.booru.content.settings
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
 import com.makentoshe.booruchan.common.api.Boor
-import com.makentoshe.booruchan.common.api.HttpClient
 
-class SettingsContentViewModel(@JvmField val booru: Boor, client: HttpClient) : ViewModel() {
+class SettingsContentViewModel(@JvmField val booru: Boor) : ViewModel() {
 
 
     class Factory(private val booru: Boor) : ViewModelProvider.NewInstanceFactory() {
 
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass == SettingsContentViewModel::class.java) {
-                return SettingsContentViewModel(booru, HttpClient()) as T
+                return SettingsContentViewModel(booru) as T
             }
             return super.create(modelClass)
         }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/users/UsersContentViewModel.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/content/users/UsersContentViewModel.kt
@@ -3,16 +3,15 @@ package com.makentoshe.booruchan.booru.content.users
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
 import com.makentoshe.booruchan.common.api.Boor
-import com.makentoshe.booruchan.common.api.HttpClient
 
-class UsersContentViewModel(@JvmField val booru: Boor, client: HttpClient) : ViewModel() {
+class UsersContentViewModel(@JvmField val booru: Boor) : ViewModel() {
 
 
     class Factory(private val booru: Boor) : ViewModelProvider.NewInstanceFactory() {
 
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass == UsersContentViewModel::class.java) {
-                return UsersContentViewModel(booru, HttpClient()) as T
+                return UsersContentViewModel(booru) as T
             }
             return super.create(modelClass)
         }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/booru/view/BooruActivity.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/booru/view/BooruActivity.kt
@@ -17,6 +17,7 @@ import com.makentoshe.booruchan.booru.BooruViewModel
 import com.makentoshe.booruchan.booru.content.ContentViewModel
 import com.makentoshe.booruchan.booru.content.view.ContentFragment
 import com.makentoshe.booruchan.booru.panel.PanelViewModel
+import com.makentoshe.booruchan.common.api.HttpClient
 import com.makentoshe.booruchan.common.api.factory.Factory
 import com.makentoshe.booruchan.sample.view.SampleActivity
 import org.jetbrains.anko.setContentView
@@ -35,7 +36,7 @@ class BooruActivity : Activity() {
     }
 
     private fun createViewModels() {
-        val booru = Factory.createFactory(intent.getStringExtra(BOORU_EXTRA)).createService()
+        val booru = Factory.createFactory(intent.getStringExtra(BOORU_EXTRA)).createService(HttpClient())
         ViewModelProviders.of(this, PanelViewModel.Factory(booru))[PanelViewModel::class.java]
         ViewModelProviders.of(this, ContentViewModel.Factory(booru))[ContentViewModel::class.java]
         ViewModelProviders.of(this)[BooruViewModel::class.java]

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/Boor.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/Boor.kt
@@ -2,7 +2,7 @@ package com.makentoshe.booruchan.common.api
 
 import java.io.Serializable
 
-abstract class Boor(private val requestAPI: BoorRequestAPI): BoorNetwork(requestAPI), Serializable {
+abstract class Boor(private val requestAPI: BoorRequestAPI, client: HttpClient): BoorNetwork(requestAPI, client), Serializable {
 
     abstract fun getBooruName(): String
 

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/BoorNetwork.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/BoorNetwork.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.async
 import java.io.Serializable
 
-abstract class BoorNetwork(private val api: BoorRequestAPI, protected val client: HttpClient) : Serializable {
+abstract class BoorNetwork(private val api: BoorRequestAPI, @JvmField val client: HttpClient) : Serializable {
 
     abstract suspend fun getAutocompleteSearchVariations(term: String): List<String>
 
@@ -15,5 +15,5 @@ abstract class BoorNetwork(private val api: BoorRequestAPI, protected val client
 
     abstract suspend fun getListOfLastCommentedPosts(page: Int, httpClient: HttpClient): List<Pair<Post, List<Comment>>>
 
-    abstract suspend fun getPostsByTags(limit: Int, tags: String, page: Int, httpClient: HttpClient): Posts<out Post>
+    abstract suspend fun getPostsByTags(limit: Int, tags: String, page: Int): Posts<out Post>
 }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/BoorNetwork.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/BoorNetwork.kt
@@ -11,8 +11,6 @@ abstract class BoorNetwork(private val api: BoorRequestAPI, @JvmField val client
 
     abstract suspend fun getAutocompleteSearchVariations(term: String): List<String>
 
-    abstract suspend fun getPostById(postId: Int, httpClient: HttpClient): Post
-
     abstract suspend fun getListOfLastCommentedPosts(page: Int): List<Pair<Post, List<Comment>>>
 
     abstract suspend fun getPostsByTags(limit: Int, tags: String, page: Int): Posts<out Post>

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/BoorNetwork.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/BoorNetwork.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.async
 import java.io.Serializable
 
-abstract class BoorNetwork(private val api: BoorRequestAPI) : Serializable {
+abstract class BoorNetwork(private val api: BoorRequestAPI, protected val client: HttpClient) : Serializable {
 
-    abstract suspend fun getAutocompleteSearchVariations(httpClient: HttpClient, term: String): List<String>
+    abstract suspend fun getAutocompleteSearchVariations(term: String): List<String>
 
     abstract suspend fun getPostById(postId: Int, httpClient: HttpClient): Post
 

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/BoorNetwork.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/BoorNetwork.kt
@@ -13,7 +13,7 @@ abstract class BoorNetwork(private val api: BoorRequestAPI, @JvmField val client
 
     abstract suspend fun getPostById(postId: Int, httpClient: HttpClient): Post
 
-    abstract suspend fun getListOfLastCommentedPosts(page: Int, httpClient: HttpClient): List<Pair<Post, List<Comment>>>
+    abstract suspend fun getListOfLastCommentedPosts(page: Int): List<Pair<Post, List<Comment>>>
 
     abstract suspend fun getPostsByTags(limit: Int, tags: String, page: Int): Posts<out Post>
 }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/HttpClient.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/HttpClient.kt
@@ -7,8 +7,10 @@ import com.github.kittinunf.fuel.core.Request
 import kotlinx.coroutines.experimental.runBlocking
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.io.Serializable
 
-class HttpClient {
+
+class HttpClient : Serializable {
 
     fun get(url: String): HttpGet {
         return HttpGet(url)

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/factory/Factory.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/factory/Factory.kt
@@ -1,11 +1,12 @@
 package com.makentoshe.booruchan.common.api.factory
 
 import com.makentoshe.booruchan.common.api.Boor
+import com.makentoshe.booruchan.common.api.HttpClient
 import com.makentoshe.booruchan.common.api.gelbooru.Gelbooru
 
 interface Factory {
 
-    fun createService(): Boor
+    fun createService(client: HttpClient): Boor
 
     companion object {
 

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/factory/GelbooruFactory.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/factory/GelbooruFactory.kt
@@ -1,11 +1,12 @@
 package com.makentoshe.booruchan.common.api.factory
 
 import com.makentoshe.booruchan.common.api.Boor
+import com.makentoshe.booruchan.common.api.HttpClient
 import com.makentoshe.booruchan.common.api.gelbooru.Gelbooru
 
 class GelbooruFactory: Factory {
 
-    override fun createService(): Boor {
-        return Gelbooru()
+    override fun createService(client: HttpClient): Boor {
+        return Gelbooru(HttpClient())
     }
 }

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/gelbooru/Gelbooru.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/gelbooru/Gelbooru.kt
@@ -42,12 +42,6 @@ class Gelbooru(httpClient: HttpClient) : Boor(GelbooruRequestAPI(), httpClient),
         return HtmlParser.parseComments(result, this::class.java)
     }
 
-    override suspend fun getPostById(
-            postId: Int, httpClient: HttpClient): com.makentoshe.booruchan.common.api.entity.Post {
-        val result = httpClient.get(getApi().getPostByIdRequest(postId)).stream()
-        return PostParser(Post::class.java).parsePosts(result).getPost(0)
-    }
-
     class Post : com.makentoshe.booruchan.common.api.entity.Post() {
 
         var previewHeight: Int = -1

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/gelbooru/Gelbooru.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/gelbooru/Gelbooru.kt
@@ -8,7 +8,7 @@ import com.makentoshe.booruchan.common.api.parser.HtmlParser
 import com.makentoshe.booruchan.common.api.parser.PostParser
 import java.io.Serializable
 
-class Gelbooru : Boor(GelbooruRequestAPI()), Serializable {
+class Gelbooru(httpClient: HttpClient) : Boor(GelbooruRequestAPI(), httpClient), Serializable {
 
     override fun getBooruName(): String {
         return "Gelbooru"
@@ -23,9 +23,8 @@ class Gelbooru : Boor(GelbooruRequestAPI()), Serializable {
         return "$day $month $year in $daytime"
     }
 
-    override suspend fun getAutocompleteSearchVariations(
-            httpClient: HttpClient, term: String): List<String> {
-        val result = httpClient.get(getApi().getAutocompleteSearchRequest(term)).stream()
+    override suspend fun getAutocompleteSearchVariations(term: String): List<String> {
+        val result = client.get(getApi().getAutocompleteSearchRequest(term)).stream()
         return AutocompleteSearchParser().parse(result)
     }
 

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/gelbooru/Gelbooru.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/gelbooru/Gelbooru.kt
@@ -36,10 +36,9 @@ class Gelbooru(httpClient: HttpClient) : Boor(GelbooruRequestAPI(), httpClient),
         return PostParser(Post::class.java).parsePosts(result)
     }
 
-    override suspend fun getListOfLastCommentedPosts(
-            page: Int, httpClient: HttpClient):
+    override suspend fun getListOfLastCommentedPosts(page: Int):
             ArrayList<Pair<com.makentoshe.booruchan.common.api.entity.Post, List<com.makentoshe.booruchan.common.api.entity.Comment>>> {
-        val result = httpClient.get(getApi().getListOfCommentsViewRequest(page)).stream()
+        val result = client.get(getApi().getListOfCommentsViewRequest(page)).stream()
         return HtmlParser.parseComments(result, this::class.java)
     }
 

--- a/app/src/main/kotlin/com/makentoshe/booruchan/common/api/gelbooru/Gelbooru.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/common/api/gelbooru/Gelbooru.kt
@@ -31,9 +31,8 @@ class Gelbooru(httpClient: HttpClient) : Boor(GelbooruRequestAPI(), httpClient),
     override suspend fun getPostsByTags(
             limit: Int,
             tags: String,
-            page: Int,
-            httpClient: HttpClient): Posts<out com.makentoshe.booruchan.common.api.entity.Post> {
-        val result = httpClient.get(getApi().getPostsByTagsRequest(limit, tags, page)).stream()
+            page: Int): Posts<out com.makentoshe.booruchan.common.api.entity.Post> {
+        val result = client.get(getApi().getPostsByTagsRequest(limit, tags, page)).stream()
         return PostParser(Post::class.java).parsePosts(result)
     }
 

--- a/app/src/main/kotlin/com/makentoshe/booruchan/sample/PageViewModel.kt
+++ b/app/src/main/kotlin/com/makentoshe/booruchan/sample/PageViewModel.kt
@@ -1,28 +1,26 @@
 package com.makentoshe.booruchan.sample
 
-import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import com.makentoshe.booruchan.common.api.Boor
-import com.makentoshe.booruchan.common.api.HttpClient
 import com.makentoshe.booruchan.common.api.entity.Post
 import com.makentoshe.booruchan.sample.view.PageFragment
 import java.io.File
 
 class PageViewModel(@JvmField val booru: Boor, @JvmField val tags: String,
-                    @JvmField val position: Int, private val client: HttpClient) : ViewModel() {
+                    @JvmField val position: Int) : ViewModel() {
 
     suspend fun loadPostData(): Post =
-            booru.getPostsByTags(1, tags, position, client).getPost(0)
+            booru.getPostsByTags(1, tags, position).getPost(0)
 
     suspend fun loadPostImage(post: Post): Bitmap {
         return when (File(post.sampleUrl).extension.toLowerCase()) {
-            "gif" -> BitmapFactory.decodeStream(client.get(post.previewUrl).stream())
-            "webm" -> BitmapFactory.decodeStream(client.get(post.previewUrl).stream())
-            else -> BitmapFactory.decodeStream(client.get(post.sampleUrl).stream())
+            "gif" -> BitmapFactory.decodeStream(booru.client.get(post.previewUrl).stream())
+            "webm" -> BitmapFactory.decodeStream(booru.client.get(post.previewUrl).stream())
+            else -> BitmapFactory.decodeStream(booru.client.get(post.sampleUrl).stream())
         }
     }
 
@@ -32,8 +30,8 @@ class PageViewModel(@JvmField val booru: Boor, @JvmField val tags: String,
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass == PageViewModel::class.java) {
                 val pos = arguments.getInt(PageFragment.ARG_POSITION)
-                val tags = arguments.getString(PageFragment.ARG_TAGS)
-                return PageViewModel(booru, tags, pos, HttpClient()) as T
+                val tags = arguments.getString(PageFragment.ARG_TAGS)!!
+                return PageViewModel(booru, tags, pos) as T
             }
             return super.create(modelClass)
         }


### PR DESCRIPTION
- Move HttpClient instance from each method param to the constructor.
- Remove all HttpClient constructor invocations except Boor factory. Now the access to the HttpClient only using a boor instance.